### PR TITLE
Add Terraform files for create ocr api stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ override.tf.json
 
 *.sh
 
+AWSCLIV2.pkg
+
 # Mac files
 .DS_Store
 ._*

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,33 @@
-# Compiled class file
-*.class
+# Local .terraform directories
+**/.terraform/*
 
-# Log file
-*.log
+# .tfstate files
+*.tfstate
+*.tfstate.*
 
-# BlueJ files
-*.ctxt
+# Crash log files
+crash.log
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Mac files
+.DS_Store
+._*

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 
+*.sh
+
 # Mac files
 .DS_Store
 ._*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ocr-api-stack
+
+Infrastructure for the ocr-api service stack.

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -119,7 +119,6 @@ module "ecs-stack" {
   vpc_id                    = local.vpc_id
   ssl_certificate_id        = var.ssl_certificate_id
   zone_id                   = var.zone_id
-  external_top_level_domain = var.external_top_level_domain
   internal_top_level_domain = var.internal_top_level_domain
   subnet_ids                = local.application_ids
   web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
@@ -137,12 +136,15 @@ module "ecs-services" {
   web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
   aws_region                = var.aws_region
   ssl_certificate_id        = var.ssl_certificate_id
-  external_top_level_domain = var.external_top_level_domain
   internal_top_level_domain = var.internal_top_level_domain
   ecs_cluster_id            = module.ecs-cluster.ecs_cluster_id
   task_execution_role_arn   = module.ecs-cluster.ecs_task_execution_role_arn
   docker_registry           = var.docker_registry
   secrets_arn_map           = module.secrets.secrets_arn_map
   log_level                 = var.log_level
+
+  # ocr-api variables
+  ocr_api_application_port  = "10000"
+  ocr_api_release_version   = var.ocr_api_release_version
 
 }

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -1,0 +1,148 @@
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.32.0"
+}
+
+terraform {
+  backend "s3" {
+  }
+}
+
+# Configure the remote state data source to acquire configuration
+# created through the code in ch-service-terraform/aws-mm-networks.
+data "terraform_remote_state" "networks" {
+  backend = "s3"
+  config = {
+    bucket = var.remote_state_bucket
+    key    = "${var.state_prefix}/${var.deploy_to}/${var.deploy_to}.tfstate"
+    region = var.aws_region
+  }
+}
+locals {
+  vpc_id            = data.terraform_remote_state.networks.outputs.vpc_id
+  application_ids   = data.terraform_remote_state.networks.outputs.application_ids
+  application_cidrs = data.terraform_remote_state.networks.outputs.application_cidrs
+}
+
+# Configure the remote state data source to acquire configuration created
+# through the code in aws-common-infrastructure-terraform/groups/networking.
+data "terraform_remote_state" "networks_common_infra" {
+  backend = "s3"
+  config = {
+    bucket = var.aws_bucket
+    key    = "aws-common-infrastructure-terraform/common-${var.aws_region}/networking.tfstate"
+    region = var.aws_region
+  }
+}
+locals {
+  internal_cidrs = values(data.terraform_remote_state.networks_common_infra.outputs.internal_cidrs)
+  vpn_cidrs      = values(data.terraform_remote_state.networks_common_infra.outputs.vpn_cidrs)
+}
+
+# Remote state data source for Ireland, required for Concourse management CIDRs
+data "terraform_remote_state" "networks_common_infra_ireland" {
+  backend = "s3"
+  config = {
+    bucket = "development-eu-west-1.terraform-state.ch.gov.uk"
+    key    = "aws-common-infrastructure-terraform/common-eu-west-1/networking.tfstate"
+    region = "eu-west-1"
+  }
+}
+locals {
+  management_private_subnet_cidrs = values(data.terraform_remote_state.networks_common_infra_ireland.outputs.management_private_subnet_cidrs)
+}
+
+# Configure the remote state data source to acquire configuration
+# created through the code in the services-stack-configs stack in the
+# aws-common-infrastructure-terraform repo.
+data "terraform_remote_state" "services-stack-configs" {
+  backend = "s3"
+  config = {
+    bucket = var.aws_bucket # aws-common-infrastructure-terraform repo uses the same remote state bucket
+    key    = "aws-common-infrastructure-terraform/common-${var.aws_region}/services-stack-configs.tfstate"
+    region = var.aws_region
+  }
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}
+
+data "vault_generic_secret" "secrets" {
+  path = "applications/${var.aws_profile}/${var.environment}/${local.stack_fullname}"
+}
+
+locals {
+  # stack name is hardcoded here in main.tf for this stack. It should not be overridden per env
+  stack_name       = "ocr-api"
+  stack_fullname   = "${local.stack_name}-stack"
+  name_prefix      = "${local.stack_name}-${var.environment}"
+}
+
+module "ecs-cluster" {
+  source = "git::git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.1"
+
+  stack_name                 = local.stack_name
+  name_prefix                = local.name_prefix
+  environment                = var.environment
+  vpc_id                     = local.vpc_id
+  subnet_ids                 = local.application_ids
+  ec2_key_pair_name          = var.ec2_key_pair_name
+  ec2_instance_type          = var.ec2_instance_type
+  ec2_image_id               = var.ec2_image_id
+  asg_max_instance_count     = var.asg_max_instance_count
+  asg_min_instance_count     = var.asg_min_instance_count
+  asg_desired_instance_count = var.asg_desired_instance_count
+}
+
+module "secrets" {
+  source = "./module-secrets"
+
+  stack_name  = local.stack_name
+  name_prefix = local.name_prefix
+  environment = var.environment
+  kms_key_id  = data.terraform_remote_state.services-stack-configs.outputs.services_stack_configs_kms_key_id
+  secrets     = data.vault_generic_secret.secrets.data
+}
+
+module "ecs-stack" {
+  source = "./module-ecs-stack"
+
+  stack_name                = local.stack_name
+  name_prefix               = local.name_prefix
+  environment               = var.environment
+  vpc_id                    = local.vpc_id
+  ssl_certificate_id        = var.ssl_certificate_id
+  zone_id                   = var.zone_id
+  external_top_level_domain = var.external_top_level_domain
+  internal_top_level_domain = var.internal_top_level_domain
+  subnet_ids                = local.application_ids
+  web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
+}
+
+module "ecs-services" {
+  source = "./module-ecs-services"
+
+  name_prefix               = local.name_prefix
+  environment               = var.environment
+  tocr-api-lb-arn          = module.ecs-stack.ocr-api-lb-listener-arn
+  ocr-api-lb-listener-arn = module.ecs-stack.ocr-api-lb-listener-arn
+  vpc_id                    = local.vpc_id
+  subnet_ids                = local.application_ids
+  web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
+  aws_region                = var.aws_region
+  ssl_certificate_id        = var.ssl_certificate_id
+  external_top_level_domain = var.external_top_level_domain
+  internal_top_level_domain = var.internal_top_level_domain
+  ecs_cluster_id            = module.ecs-cluster.ecs_cluster_id
+  task_execution_role_arn   = module.ecs-cluster.ecs_task_execution_role_arn
+  docker_registry           = var.docker_registry
+  secrets_arn_map           = module.secrets.secrets_arn_map
+  log_level                 = var.log_level
+
+}

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -144,7 +144,7 @@ module "ecs-services" {
   log_level                 = var.log_level
 
   # ocr-api variables
-  ocr_api_application_port  = "10000"
+  ocr_api_application_port  = "8080"
   ocr_api_release_version   = var.ocr_api_release_version
 
 }

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -1,7 +1,6 @@
 [
     {
         "environment": [
-            { "name": "PORT", "value": "${ocr_api_proxy_port}" },
             { "name": "LOGLEVEL", "value": "${log_level}" }
         ],
         "name": "${service_name}",
@@ -10,7 +9,7 @@
         "memory": 512,
         "mountPoints": [],
         "portMappings": [{
-            "containerPort": ${ocr_api_proxy_port},
+            "containerPort": 8080,
             "hostPort": 0,
             "protocol": "tcp"
         }],

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -1,0 +1,29 @@
+[
+    {
+        "environment": [
+            { "name": "PORT", "value": "${ocr-api_proxy_port}" },
+            { "name": "LOGLEVEL", "value": "${log_level}" }
+        ],
+        "name": "${service_name}",
+        "image": "${docker_registry}/${service_name}:${ocr-api_release_version}",
+        "cpu": 1,
+        "memory": 512,
+        "mountPoints": [],
+        "portMappings": [{
+            "containerPort": ${ocr-api_proxy_port},
+            "hostPort": 0,
+            "protocol": "tcp"
+        }],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-create-group": "true",
+                "awslogs-region": "${aws_region}",
+                "awslogs-group": "/ecs/${name_prefix}/${service_name}",
+                "awslogs-stream-prefix": "ecs"
+            }
+        },
+        "volumesFrom": [],
+        "essential": true
+    }
+]

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -6,7 +6,7 @@
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
         "cpu": 1,
-        "memory": 512,
+        "memory": 2048,
         "mountPoints": [],
         "portMappings": [{
             "containerPort": 8080,

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -9,7 +9,7 @@
         "memory": 2048,
         "mountPoints": [],
         "portMappings": [{
-            "containerPort": 8080,
+            "containerPort": ${ocr_api_application_port},
             "hostPort": 0,
             "protocol": "tcp"
         }],

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -1,16 +1,16 @@
 [
     {
         "environment": [
-            { "name": "PORT", "value": "${ocr-api_proxy_port}" },
+            { "name": "PORT", "value": "${ocr_api_proxy_port}" },
             { "name": "LOGLEVEL", "value": "${log_level}" }
         ],
         "name": "${service_name}",
-        "image": "${docker_registry}/${service_name}:${ocr-api_release_version}",
+        "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
         "cpu": 1,
         "memory": 512,
         "mountPoints": [],
         "portMappings": [{
-            "containerPort": ${ocr-api_proxy_port},
+            "containerPort": ${ocr_api_proxy_port},
             "hostPort": 0,
             "protocol": "tcp"
         }],

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -23,11 +23,10 @@ locals {
       environment                : var.environment
       name_prefix                : var.name_prefix
       aws_region                 : var.aws_region
-      external_top_level_domain  : var.external_top_level_domain
       log_level                  : var.log_level
       docker_registry            : var.docker_registry
 
-      # tdg specific configs
+      # ocr specific configs
       ocr_api_release_version    : var.ocr_api_release_version
       ocr_api_proxy_port         : local.ocr_api_proxy_port
     },

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -51,7 +51,7 @@ resource "aws_lb_target_group" "ocr-api-target_group" {
     unhealthy_threshold = "2"
     interval            = "30"
     matcher             = "200"
-    path                = "/healthcheck"
+    path                = "/ocr-api/healthcheck"
     port                = "traffic-port"
     protocol            = "HTTP"
     timeout             = "5"
@@ -67,6 +67,6 @@ resource "aws_lb_listener_rule" "ocr-api" {
   }
   condition {
     field  = "path-pattern"
-    values = ["/*"]
+    values = ["/ocr-api/*"]
   }
 }

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -1,6 +1,6 @@
 locals {
   service_name = "ocr-api"
-  ocr-api_proxy_port = 11000 # local port number defined for proxy target of tdg service sitting behind eric
+  ocr_api_proxy_port = 11000 # local port number defined for proxy target of tdg service sitting behind eric
 }
 
 resource "aws_ecs_service" "ocr-api-ecs-service" {
@@ -11,7 +11,7 @@ resource "aws_ecs_service" "ocr-api-ecs-service" {
   depends_on      = [var.tocr-api-lb-arn]
   load_balancer {
     target_group_arn = aws_lb_target_group.ocr-api-target_group.arn
-    container_port   = var.ocr-api_application_port
+    container_port   = var.ocr_api_application_port
     container_name   = "ocr-api" # [ALB -> target group -> ocr-api] 
   }
 }
@@ -28,8 +28,8 @@ locals {
       docker_registry            : var.docker_registry
 
       # tdg specific configs
-      ocr-api_release_version    : var.ocr-api_release_version
-      ocr-api_proxy_port         : local.ocr-api_proxy_port
+      ocr_api_release_version    : var.ocr_api_release_version
+      ocr_api_proxy_port         : local.ocr_api_proxy_port
     },
       var.secrets_arn_map
   )
@@ -45,7 +45,7 @@ resource "aws_ecs_task_definition" "ocr-api-task-definition" {
 
 resource "aws_lb_target_group" "ocr-api-target_group" {
   name     = "${var.environment}-${local.service_name}"
-  port     = var.ocr-api_application_port
+  port     = var.ocr_api_application_port
   protocol = "HTTP"
   # Add heath check port here in drop 2
 }

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -1,0 +1,64 @@
+locals {
+  service_name = "ocr-api"
+  ocr-api_proxy_port = 11000 # local port number defined for proxy target of tdg service sitting behind eric
+}
+
+resource "aws_ecs_service" "ocr-api-ecs-service" {
+  name            = "${var.environment}-${local.service_name}"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.ocr-api-task-definition.arn
+  desired_count   = 1
+  depends_on      = [var.tocr-api-lb-arn]
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ocr-api-target_group.arn
+    container_port   = var.ocr-api_application_port
+    container_name   = "ocr-api" # [ALB -> target group -> ocr-api] 
+  }
+}
+
+locals {
+  definition = merge(
+    {
+      service_name               : local.service_name
+      environment                : var.environment
+      name_prefix                : var.name_prefix
+      aws_region                 : var.aws_region
+      external_top_level_domain  : var.external_top_level_domain
+      log_level                  : var.log_level
+      docker_registry            : var.docker_registry
+
+      # tdg specific configs
+      ocr-api_release_version    : var.ocr-api_release_version
+      ocr-api_proxy_port         : local.ocr-api_proxy_port
+    },
+      var.secrets_arn_map
+  )
+}
+
+resource "aws_ecs_task_definition" "ocr-api-task-definition" {
+  family                = "${var.environment}-${local.service_name}"
+  execution_role_arn    = var.task_execution_role_arn
+  container_definitions = templatefile(
+    "${path.module}/${local.service_name}-task-definition.tmpl", local.definition
+  )
+}
+
+resource "aws_lb_target_group" "ocr-api-target_group" {
+  name     = "${var.environment}-${local.service_name}"
+  port     = var.ocr-api_application_port
+  protocol = "HTTP"
+  # Add heath check port here in drop 2
+}
+
+resource "aws_lb_listener_rule" "ocr-api" {
+  listener_arn = var.ocr-api-lb-listener-arn
+  priority     = 1
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ocr-api-target_group.arn
+  }
+  condition {
+    field  = "path-pattern"
+    values = ["/ocr-api/*"]
+  }
+}

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -1,6 +1,5 @@
 locals {
   service_name = "ocr-api"
-  ocr_api_proxy_port = 11000 # this is for eric and probably can delete it but will review with others first
 }
 
 resource "aws_ecs_service" "ocr-api-ecs-service" {
@@ -11,7 +10,7 @@ resource "aws_ecs_service" "ocr-api-ecs-service" {
   depends_on      = [var.tocr-api-lb-arn]
   load_balancer {
     target_group_arn = aws_lb_target_group.ocr-api-target_group.arn
-    container_port   = local.ocr_api_proxy_port
+    container_port   =  var.ocr_api_application_port
     container_name   = "ocr-api" # [ALB -> target group -> ocr-api] 
   }
 }
@@ -28,7 +27,7 @@ locals {
 
       # ocr specific configs
       ocr_api_release_version    : var.ocr_api_release_version
-      ocr_api_proxy_port         : local.ocr_api_proxy_port
+      ocr_api_application_port   : var.ocr_api_application_port
     },
       var.secrets_arn_map
   )
@@ -45,7 +44,7 @@ resource "aws_ecs_task_definition" "ocr-api-task-definition" {
 resource "aws_lb_target_group" "ocr-api-target_group" {
   name     = "${var.environment}-${local.service_name}"
   port     = var.ocr_api_application_port
-  protocol = "HTTP"
+  protocol = "HTTP" 
   vpc_id   = var.vpc_id
   health_check {
     healthy_threshold   = "5"

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -1,0 +1,88 @@
+# Environment
+variable "environment" {
+  type        = string
+  description = "The environment name, defined in envrionments vars."
+}
+variable "aws_region" {
+  type        = string
+  description = "The AWS region for deployment."
+}
+
+# Networking
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC for the target group and security group."
+}
+variable "tocr-api-lb-arn" {
+  type        = string
+  description = "The ARN of the load balancer created in the ecs-stack module."
+}
+variable "ocr-api-lb-listener-arn" {
+  type        = string
+  description = "The ARN of the lb listener created in the ecs-stack module."
+}
+variable "subnet_ids" {
+  type        = string
+  description = "Subnet IDs of application subnets from aws-mm-networks remote state."
+}
+variable "web_access_cidrs" {
+  type        = list(string)
+  description = "Subnet CIDRs for web ingress rules in the security group."
+}
+
+# DNS
+variable "internal_top_level_domain" {
+  type        = string
+  description = "The type levelel of the DNS domain for internal access."
+}
+
+# ECS Service
+variable "name_prefix" {
+  type        = string
+  description = "The name prefix to be used for stack / environment name spacing."
+}
+variable "ecs_cluster_id" {
+  type        = string
+  description = "The ARN of the ECS cluster to deploy the service to."
+}
+
+# Docker Container
+variable "docker_registry" {
+  type        = string
+  description = "The FQDN of the Docker registry."
+}
+variable "task_execution_role_arn" {
+  type        = string
+  description = "The ARN of the task execution role that the container can assume."
+}
+variable "log_level" {
+  type        = string
+  description = "The log level to be set in the environment variables for the container."
+}
+
+# Certificates
+variable "ssl_certificate_id" {
+  type        = string
+  description = "The ARN of the certificate for https access through the ALB."
+}
+
+# Secrets
+variable "secrets_arn_map" {
+  type = map(string)
+  description = "The ARNs for all secrets"
+}
+
+# ------------------------------------------------------------------------------
+
+# Services
+
+
+# ocr-api
+variable "ocr-api_release_version" {
+  type        = string
+  description = "The release version for the ocr-api service."
+}
+variable "ocr-api_application_port" {
+  type        = string
+  description = "The port number for the ocr-api service."
+}

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -78,11 +78,11 @@ variable "secrets_arn_map" {
 
 
 # ocr-api
-variable "ocr-api_release_version" {
+variable "ocr_api_release_version" {
   type        = string
   description = "The release version for the ocr-api service."
 }
-variable "ocr-api_application_port" {
+variable "ocr_api_application_port" {
   type        = string
   description = "The port number for the ocr-api service."
 }

--- a/groups/stack/module-ecs-stack/load-balancer.tf
+++ b/groups/stack/module-ecs-stack/load-balancer.tf
@@ -1,0 +1,34 @@
+resource "aws_lb" "ocr-api-lb" {
+  name            = "${var.stack_name}-${var.environment}-lb"
+  security_groups = [aws_security_group.internal-service-sg.id]
+  subnets         = flatten([split(",", var.subnet_ids)])
+  internal        = true
+}
+
+resource "aws_lb_listener" "ocr-api-lb-listener" {
+  load_balancer_arn = aws_lb.ocr-api-lb.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.ssl_certificate_id
+  default_action {
+    type             = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "OK"
+      status_code  = "200"
+    }
+  }
+}
+
+resource "aws_route53_record" "ocr-api-generator-r53-record" {
+  count   = "${var.zone_id == "" ? 0 : 1}" # zone_id defaults to empty string giving count = 0 i.e. not route 53 record
+  zone_id = var.zone_id
+  name    = "ocr-api${var.external_top_level_domain}"
+  type    = "A"
+  alias {
+    name                   = aws_lb.ocr-api-lb.dns_name
+    zone_id                = aws_lb.ocr-api-lb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/groups/stack/module-ecs-stack/load-balancer.tf
+++ b/groups/stack/module-ecs-stack/load-balancer.tf
@@ -24,7 +24,7 @@ resource "aws_lb_listener" "ocr-api-lb-listener" {
 resource "aws_route53_record" "ocr-api-generator-r53-record" {
   count   = "${var.zone_id == "" ? 0 : 1}" # zone_id defaults to empty string giving count = 0 i.e. not route 53 record
   zone_id = var.zone_id
-  name    = "ocr-api${var.external_top_level_domain}"
+  name    = "ocr-api${var.internal_top_level_domain}"
   type    = "A"
   alias {
     name                   = aws_lb.ocr-api-lb.dns_name

--- a/groups/stack/module-ecs-stack/load-balancer.tf
+++ b/groups/stack/module-ecs-stack/load-balancer.tf
@@ -3,6 +3,7 @@ resource "aws_lb" "ocr-api-lb" {
   security_groups = [aws_security_group.internal-service-sg.id]
   subnets         = flatten([split(",", var.subnet_ids)])
   internal        = true
+  idle_timeout    = 400
 }
 
 resource "aws_lb_listener" "ocr-api-lb-listener" {

--- a/groups/stack/module-ecs-stack/output.tf
+++ b/groups/stack/module-ecs-stack/output.tf
@@ -1,0 +1,7 @@
+output "ocr-api-lb-listener-arn" {
+  value = aws_lb_listener.ocr-api-lb-listener.arn
+}
+
+output "ocr-api-lb-arn" {
+  value = aws_lb.ocr-api-lb.arn
+}

--- a/groups/stack/module-ecs-stack/security-groups.tf
+++ b/groups/stack/module-ecs-stack/security-groups.tf
@@ -1,0 +1,30 @@
+resource "aws_security_group" "internal-service-sg" {
+  description = "Security group for internal service albs"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.web_access_cidrs
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.web_access_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Environment = var.environment
+    Name        = "${var.name_prefix}-internal-service-sg"
+  }
+}

--- a/groups/stack/module-ecs-stack/variables.tf
+++ b/groups/stack/module-ecs-stack/variables.tf
@@ -1,0 +1,46 @@
+# ECS Service
+variable "stack_name" {
+ type        = string
+ description = "The name of the Stack / ECS Cluster."
+}
+variable "name_prefix" {
+  type        = string
+  description = "The name prefix to be used for stack / environment name spacing."
+}
+
+# Environment
+variable "environment" {
+  type        = string
+  description = "The environment name, defined in envrionments vars."
+}
+
+# Networking
+variable "subnet_ids" {
+  type        = string
+  description = "Subnet IDs of application subnets from aws-mm-networks remote state."
+}
+variable "web_access_cidrs" {
+  type        = list(string)
+  description = "Subnet CIDRs for web ingress rules in the security group."
+}
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC for the target group and security group."
+}
+
+# DNS
+variable "zone_id" {
+  type        = string
+  description = "The ID of the hosted zone to contain the Route 53 record."
+}
+
+variable "internal_top_level_domain" {
+  type        = string
+  description = "The type levelel of the DNS domain for internal access."
+}
+
+# Certificates
+variable "ssl_certificate_id" {
+  type        = string
+  description = "The ARN of the certificate for https access through the ALB."
+}

--- a/groups/stack/module-secrets/output.tf
+++ b/groups/stack/module-secrets/output.tf
@@ -1,0 +1,11 @@
+//---------------- START: Environment Secrets for services ---------------------
+
+output "secrets_arn_map" {
+  value = {
+  for secret in aws_ssm_parameter.secret_parameters:
+  secret.description => secret.arn
+  }
+  description = "The ARNs for all secrets"
+}
+
+//---------------- END: Environment Secrets for services ---------------------

--- a/groups/stack/module-secrets/parameters.tf
+++ b/groups/stack/module-secrets/parameters.tf
@@ -1,0 +1,9 @@
+resource "aws_ssm_parameter" "secret_parameters" {
+  for_each = var.secrets
+    name  = "/${var.name_prefix}/${each.key}"
+    key_id = var.kms_key_id
+    description = each.key
+    type  = "SecureString"
+    overwrite = "true"
+    value = each.value
+}

--- a/groups/stack/module-secrets/variables.tf
+++ b/groups/stack/module-secrets/variables.tf
@@ -1,0 +1,25 @@
+# Environment
+variable "environment" {
+  type        = string
+  description = "The environment name, defined in envrionments vars."
+}
+
+# ECS Service
+variable "stack_name" {
+  type        = string
+  description = "The name of the Stack / ECS Cluster."
+}
+variable "name_prefix" {
+  type        = string
+  description = "The name prefix to be used for parameter name spacing."
+}
+
+# Secrets
+variable "secrets" {
+  type        = map
+  description = "The secrets to be added to Parameter Store."
+}
+variable "kms_key_id" {
+  type        = string
+  description = "The KMS key alias for encrypting the values for Parameter Store. "
+}

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -1,0 +1,16 @@
+aws_bucket = "development-eu-west-2.terraform-state.ch.gov.uk"
+remote_state_bucket = "ch-development-terraform-state-london"
+environment = "parent1"
+deploy_to = "development"
+state_prefix = "env:/development"
+aws_profile = "development-eu-west-2"
+
+# Certificate for https access through ALB
+ssl_certificate_id = "arn:aws:acm:eu-west-2:169942020521:certificate/189427a3-3662-41ca-85d8-e1f42b6ea07e"
+zone_id = "Z2KSI4Z5ZN9NT0"
+internal_top_level_domain = "-parent1.development.aws.internal"
+
+ec2_key_pair_name = "chs-parent1"
+
+# shared configs
+log_level = "TRACE"

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -1,0 +1,121 @@
+# Environment
+variable "environment" {
+  type        = string
+  description = "The environment name, defined in envrionments vars."
+}
+variable "aws_region" {
+  default     = "eu-west-2"
+  type        = string
+  description = "The AWS region for deployment."
+}
+variable "aws_profile" {
+  default     = "development-eu-west-2"
+  type        = string
+  description = "The AWS profile to use for deployment."
+}
+
+# Terraform
+variable "aws_bucket" {
+  type        = string
+  description = "The bucket used to store the current terraform state files"
+}
+variable "remote_state_bucket" {
+  type        = string
+  description = "Alternative bucket used to store the remote state files from ch-service-terraform"
+}
+variable "state_prefix" {
+  type        = string
+  description = "The bucket prefix used with the remote_state_bucket files."
+}
+variable "deploy_to" {
+  type        = string
+  description = "Bucket namespace used with remote_state_bucket and state_prefix."
+}
+
+# Docker Container
+variable "docker_registry" {
+  type        = string
+  description = "The FQDN of the Docker registry."
+}
+variable "log_level" {
+  default     = "INFO"
+  type        = string
+  description = "The log level for services to use: TRACE, DEBUG, INFO or ERROR"
+}
+
+# EC2
+variable "ec2_key_pair_name" {
+  type        = string
+  description = "The key pair for SSH access to ec2 instances in the clusters."
+}
+variable "ec2_instance_type" {
+  default     = "t3.medium"
+  type        = string
+  description = "The instance type for ec2 instances in the clusters."
+}
+variable "ec2_image_id" {
+  default     = "ami-007ef488b3574da6b" # ECS optimized Linux in London created 16/10/2019
+  type        = string
+  description = "The machine image name for the ECS cluster launch configuration."
+}
+
+# Auto-scaling Group
+variable "asg_max_instance_count" {
+  default     = 1
+  type        = number
+  description = "The maximum allowed number of instances in the autoscaling group for the cluster."
+}
+variable "asg_min_instance_count" {
+  default     = 1
+  type        = number
+  description = "The minimum allowed number of instances in the autoscaling group for the cluster."
+}
+variable "asg_desired_instance_count" {
+  default     = 1
+  type        = number
+  description = "The desired number of instances in the autoscaling group for the cluster. Must fall within the min/max instance count range."
+}
+
+# Certificates
+variable "ssl_certificate_id" {
+  type        = string
+  description = "The ARN of the certificate for https access through the ALB."
+}
+
+# DNS
+variable "zone_id" {
+  default = "" # default of empty string is used as conditional when creating route53 records i.e. if no zone_id provided then no route53
+  type        = string
+  description = "The ID of the hosted zone to contain the Route 53 record."
+}
+variable "external_top_level_domain" {
+  type        = string
+  description = "The type levelel of the DNS domain for external access."
+}
+variable "internal_top_level_domain" {
+  type        = string
+  description = "The type levelel of the DNS domain for internal access."
+}
+
+# Vault
+variable "vault_username" {
+  type        = string
+  description = "The username used by the Vault provider."
+}
+variable "vault_password" {
+  type        = string
+  description = "The password used by the Vault provider."
+}
+
+# ------------------------------------------------------------------------------
+# Services
+# ------------------------------------------------------------------------------
+
+
+# ocr-api
+
+variable "ocr-api_release_version" {
+  type        = string
+  description = "The release version for the ocr-api service."
+}
+

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -88,10 +88,6 @@ variable "zone_id" {
   type        = string
   description = "The ID of the hosted zone to contain the Route 53 record."
 }
-variable "external_top_level_domain" {
-  type        = string
-  description = "The type levelel of the DNS domain for external access."
-}
 variable "internal_top_level_domain" {
   type        = string
   description = "The type levelel of the DNS domain for internal access."

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -114,7 +114,7 @@ variable "vault_password" {
 
 # ocr-api
 
-variable "ocr-api_release_version" {
+variable "ocr_api_release_version" {
   type        = string
   description = "The release version for the ocr-api service."
 }


### PR DESCRIPTION
Jira IVP-1113

This pipeline covers adding the ocr-api service so that it is deployed to parent1 ECS environment for Drop 1 of the IVP-2 artcicles of association release.

These terraform files have been used from a mac to create the AWS environments (using terraform-runner)