### PR TITLE
Feature/add env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ This consists of one ECS Cluster with one microservice (ocr-api)
 
 These are configured in the profile environmental vars files (no defaults set):
 
-|     Variable       | Description                                                               |
-|---                 |---                                                                        |
+|     Variable                    | Description                                                                       |
+|---                              |---                                                                                |
+| ec2_instance_type               | See [AWS Instance Types)[https://aws.amazon.com/ec2/instance-types/]              |
 | ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
+
+** Make sure that the CPU and Memory values are in the range of the ec2_instance_type (the plan will be made and applied but fail in deployment with no clear error messages).
 
 ## Internal / external naming
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ These are configured in the profile environmental vars files (no defaults set):
 |     Variable                    | Description                                                                       |
 |---                              |---                                                                                |
 | ec2_instance_type               | See [AWS Instance Types)[https://aws.amazon.com/ec2/instance-types/]              |
+| machine_cpu_count               | The number of vCPUs the ocr-api uses.                                             |
+| machine_amount_of_memory_mib    | The amount of memory in MiB to allocate to the ocr-api.                                  |
 | ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
 
 ** Make sure that the CPU and Memory values are in the range of the ec2_instance_type (the plan will be made and applied but fail in deployment with no clear error messages).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ These are configured in the profile environmental vars files (no defaults set):
 |     Variable                    | Description                                                                       |
 |---                              |---                                                                                |
 | ec2_instance_type               | See [AWS Instance Types)[https://aws.amazon.com/ec2/instance-types/]              |
+| number_of_tasks                 | The number of instances of the ocr-api task to run                                |
 | machine_cpu_count               | The number of vCPUs the ocr-api uses.                                             |
 | machine_amount_of_memory_mib    | The amount of memory in MiB to allocate to the ocr-api.                                  |
 | ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |

--- a/README.md
+++ b/README.md
@@ -4,10 +4,22 @@ Infrastructure for the ocr-api service stack.
 
 This consists of one ECS Cluster with one microservice (ocr-api)
 
+## Performance Variables
+
+These are configured in the profile environmental vars files (no defaults set):
+
+|     Variable       | Description                                                               |
+|---                 |---                                                                        |
+| ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
+
+## Internal / external naming
+
 Notes on the internal / external naming:
 
 - internal = DNS names within the AWS cluster that are only used for traffic within (internal to) the environment
 - external = DNS names exposing specific services to users outside (external to) the cluster e.g. other CH services, testers etc
 - so its not a public/private thing its how functionality/services are used - within the cluster is internal DNS, outside users require the external address.
 
-No secrets are required in this stack
+## Secrets
+
+No secrets are required in this application stack

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -131,7 +131,7 @@ module "ecs-services" {
   log_level                 = var.log_level
 
   # ocr-api variables
-  ocr_api_application_port  = "8080"
-  ocr_api_release_version   = var.ocr_api_release_version
-
+  ocr_api_application_port       = "8080"
+  ocr_api_release_version        = var.ocr_api_release_version
+  ocr_tesseract_thread_pool_size = var.ocr_tesseract_thread_pool_size
 }

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -134,4 +134,8 @@ module "ecs-services" {
   ocr_api_application_port       = "8080"
   ocr_api_release_version        = var.ocr_api_release_version
   ocr_tesseract_thread_pool_size = var.ocr_tesseract_thread_pool_size
+
+  # machine properties
+  machine_cpu_count              = var.machine_cpu_count
+  machine_amount_of_memory_mib   = var.machine_amount_of_memory_mib
 }

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -134,6 +134,7 @@ module "ecs-services" {
   ocr_api_application_port       = "8080"
   ocr_api_release_version        = var.ocr_api_release_version
   ocr_tesseract_thread_pool_size = var.ocr_tesseract_thread_pool_size
+  number_of_tasks                = var.number_of_tasks
 
   # machine properties
   machine_cpu_count              = var.machine_cpu_count

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -7,7 +7,7 @@
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
         "cpu": 2,
-        "memory": 4096,
+        "memory": 3072,
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${ocr_api_application_port},

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -6,8 +6,8 @@
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
-        "cpu": 2,
-        "memory": 3072,
+        "cpu": ${machine_cpu_count},
+        "memory": ${machine_amount_of_memory_mib},
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${ocr_api_application_port},

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -2,7 +2,7 @@
     {
         "environment": [
             { "name": "LOGLEVEL", "value": "${log_level}" },
-            { "name" : "OCR_TESSERACT_THREAD_POOL_SIZE", "value": "3" }
+            { "name" : "OCR_TESSERACT_THREAD_POOL_SIZE", "value": "2" }
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -6,8 +6,8 @@
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
-        "cpu": 1,
-        "memory": 2048,
+        "cpu": 2,
+        "memory": 4096,
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${ocr_api_application_port},

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -6,6 +6,8 @@
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
+        "cpu": 2,
+        "memory": 4096,
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${ocr_api_application_port},

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -6,8 +6,6 @@
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",
-        "cpu": 2,
-        "memory": 4096,
         "mountPoints": [],
         "portMappings": [{
             "containerPort": ${ocr_api_application_port},

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -1,7 +1,8 @@
 [
     {
         "environment": [
-            { "name": "LOGLEVEL", "value": "${log_level}" }
+            { "name": "LOGLEVEL", "value": "${log_level}" },
+            { "name" : "OCR_TESSERACT_THREAD_POOL_SIZE", "value": "3" }
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -2,7 +2,7 @@
     {
         "environment": [
             { "name": "LOGLEVEL", "value": "${log_level}" },
-            { "name" : "OCR_TESSERACT_THREAD_POOL_SIZE", "value": "2" }
+            { "name" : "OCR_TESSERACT_THREAD_POOL_SIZE", "value": "${ocr_tesseract_thread_pool_size}" }
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -26,8 +26,9 @@ locals {
       docker_registry            : var.docker_registry
 
       # ocr specific configs
-      ocr_api_release_version    : var.ocr_api_release_version
-      ocr_api_application_port   : var.ocr_api_application_port
+      ocr_api_release_version        : var.ocr_api_release_version
+      ocr_api_application_port       : var.ocr_api_application_port
+      ocr_tesseract_thread_pool_size : var.ocr_tesseract_thread_pool_size
     }
   )
 }

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -29,6 +29,10 @@ locals {
       ocr_api_release_version        : var.ocr_api_release_version
       ocr_api_application_port       : var.ocr_api_application_port
       ocr_tesseract_thread_pool_size : var.ocr_tesseract_thread_pool_size
+
+      # machine properties
+      machine_cpu_count              : var.machine_cpu_count
+      machine_amount_of_memory_mib   : var.machine_amount_of_memory_mib
     }
   )
 }

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "ocr-api-ecs-service" {
   name            = "${var.environment}-${local.service_name}"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.ocr-api-task-definition.arn
-  desired_count   = 2
+  desired_count   = var.number_of_tasks
   depends_on      = [var.tocr-api-lb-arn]
   load_balancer {
     target_group_arn = aws_lb_target_group.ocr-api-target_group.arn
@@ -29,6 +29,7 @@ locals {
       ocr_api_release_version        : var.ocr_api_release_version
       ocr_api_application_port       : var.ocr_api_application_port
       ocr_tesseract_thread_pool_size : var.ocr_tesseract_thread_pool_size
+      number_of_tasks                : var.number_of_tasks
 
       # machine properties
       machine_cpu_count              : var.machine_cpu_count

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "ocr-api-ecs-service" {
   name            = "${var.environment}-${local.service_name}"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.ocr-api-task-definition.arn
-  desired_count   = 1
+  desired_count   = 2
   depends_on      = [var.tocr-api-lb-arn]
   load_balancer {
     target_group_arn = aws_lb_target_group.ocr-api-target_group.arn

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -63,6 +63,10 @@ variable "log_level" {
   type        = string
   description = "The log level to be set in the environment variables for the container."
 }
+variable "ocr_tesseract_thread_pool_size" {
+  type        = string
+  description = "The number of threads used in the ocr-api application for Tesseract processing (Image to text)"
+}
 
 # Certificates
 variable "ssl_certificate_id" {

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -74,6 +74,16 @@ variable "ssl_certificate_id" {
   description = "The ARN of the certificate for https access through the ALB."
 }
 
+# Machine properties
+variable "machine_cpu_count" {
+  type        = number
+  description = "The number of vCPUs the ocr-api uses."
+}
+variable "machine_amount_of_memory_mib" {
+  type        = number
+  description = "The amount of memory to allocate to the ocr-api."
+}
+
 # ------------------------------------------------------------------------------
 
 # Services

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -49,6 +49,10 @@ variable "ecs_cluster_id" {
   type        = string
   description = "The ARN of the ECS cluster to deploy the service to."
 }
+variable "number_of_tasks" {
+  type        = number
+  description = "The number of instances of the ocr-api task to run" 
+}
 
 # Docker Container
 variable "docker_registry" {

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -18,4 +18,4 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "2"
 
 # app cluster performance
-ec2_instance_type = "c6g.large"
+ec2_instance_type = "t3.medium"

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -19,6 +19,7 @@ ocr_tesseract_thread_pool_size = "2"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
+number_of_tasks = 1
 
 # machine properties
 machine_cpu_count = 2

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -19,3 +19,7 @@ ocr_tesseract_thread_pool_size = "2"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
+
+# machine properties
+machine_cpu_count = 2
+machine_amount_of_memory_mib = 3072

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -16,3 +16,6 @@ ec2_key_pair_name = "chs-cidev"
 # app configs
 log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "2"
+
+# app cluster performance
+ec2_instance_type = "c6g.large"

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -13,5 +13,6 @@ internal_top_level_domain = "-cidev.development.aws.internal"
 
 ec2_key_pair_name = "chs-cidev"
 
-# shared configs
-log_level = "TRACE"
+# app configs
+log_level = "DEBUG"
+ocr_tesseract_thread_pool_size = "2"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -19,3 +19,7 @@ ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
+
+# machine properties
+machine_cpu_count = 2
+machine_amount_of_memory_mib = 2048

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -18,4 +18,4 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
-ec2_instance_type = "c6g.large"
+ec2_instance_type = "t3.medium"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -16,3 +16,6 @@ ec2_key_pair_name = "chs-parent1"
 # app configs
 log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "3"
+
+# app cluster performance
+ec2_instance_type = "c6g.large"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -19,6 +19,7 @@ ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
+number_of_tasks = 3
 
 # machine properties
 machine_cpu_count = 2

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -13,5 +13,6 @@ internal_top_level_domain = "-parent1.development.aws.internal"
 
 ec2_key_pair_name = "chs-parent1"
 
-# shared configs
-log_level = "TRACE"
+# app configs
+log_level = "DEBUG"
+ocr_tesseract_thread_pool_size = "3"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -19,7 +19,7 @@ ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
-number_of_tasks = 3
+number_of_tasks = 2
 
 # machine properties
 machine_cpu_count = 2

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -62,6 +62,10 @@ variable "ec2_image_id" {
   type        = string
   description = "The machine image name for the ECS cluster launch configuration."
 }
+variable "number_of_tasks" {
+  type        = number
+  description = "The number of instances of the ocr-api task to run" 
+}
 
 # Auto-scaling Group
 variable "asg_max_instance_count" {
@@ -135,3 +139,4 @@ variable "ocr_api_release_version" {
   description = "The release version for the ocr-api service."
 }
 
+number_of_tasks

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -138,5 +138,3 @@ variable "ocr_api_release_version" {
   type        = string
   description = "The release version for the ocr-api service."
 }
-
-number_of_tasks

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -37,10 +37,15 @@ variable "docker_registry" {
   type        = string
   description = "The FQDN of the Docker registry."
 }
+## Docker Container Environmental Varia
 variable "log_level" {
   default     = "INFO"
   type        = string
   description = "The log level for services to use: TRACE, DEBUG, INFO or ERROR"
+}
+variable "ocr_tesseract_thread_pool_size" {
+  type        = string
+  description = "The number of threads used in the ocr-api application for Tesseract processing (Image to text)"
 }
 
 # EC2

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -54,7 +54,6 @@ variable "ec2_key_pair_name" {
   description = "The key pair for SSH access to ec2 instances in the clusters."
 }
 variable "ec2_instance_type" {
-  default     = "t3.medium"
   type        = string
   description = "The instance type for ec2 instances in the clusters."
 }

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -113,6 +113,16 @@ variable "vault_password" {
   description = "The password used by the Vault provider."
 }
 
+# Machine properties
+variable "machine_cpu_count" {
+  type        = number
+  description = "The number of vCPUs the ocr-api uses."
+}
+variable "machine_amount_of_memory_mib" {
+  type        = number
+  description = "The amount of memory in MiB to allocate to the ocr-api."
+}
+
 # ------------------------------------------------------------------------------
 # Services
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Jira IVP-1368

ocr-api-stack configuration to allow us to parameterise key variables:

- number of application threads for IMAGE to text
- AWS Instance Type
- CPU
- Memory
- The number of tasks (instances) of the ECS Service