### PR TITLE
add staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ This consists of one ECS Cluster with one microservice (ocr-api)
 
 These are configured in the profile environmental vars files (no defaults set):
 
-|     Variable                    | Description                                                                       |
-|---                              |---                                                                                |
-| ec2_instance_type               | See [AWS Instance Types)[https://aws.amazon.com/ec2/instance-types/]              |
-| number_of_tasks                 | The number of instances of the ocr-api task to run                                |
-| machine_cpu_count               | The number of vCPUs the ocr-api uses.                                             |
-| machine_amount_of_memory_mib    | The amount of memory in MiB to allocate to the ocr-api.                                  |
-| ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
+|     Variable                   | Destroy | Description                                                                       |
+|---                             |--- |---                                                                                |
+| ec2_instance_type              | Y | See [AWS Instance Types)[https://aws.amazon.com/ec2/instance-types/]              |
+| number_of_tasks                | ? | The number of instances of the ocr-api task to run                                |
+| machine_cpu_count              | ? | The number of vCPUs the ocr-api uses.                                             |
+| machine_amount_of_memory_mib   | ? | The amount of memory in MiB to allocate to the ocr-api.                                  |
+| ocr_tesseract_thread_pool_size | N | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
 
-**Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type might define the overall memory and CPU in the cluster - Need to confirm (getting inconsistent results). When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
+- The **"Destroy"** column signifies that the environment must first be destroyed before applying this change to the environment,
+- If you create a cluster with **more than two tasks,** only two tasks will be running after creation,
+- **Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type might define the overall memory and CPU in the cluster - Need to confirm (getting inconsistent results). When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
 
 ## Internal / external naming
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are configured in the profile environmental vars files (no defaults set):
 | machine_amount_of_memory_mib    | The amount of memory in MiB to allocate to the ocr-api.                                  |
 | ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
 
-**Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type defines the overall memory and CPU in the cluster. When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
+**Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type might define the overall memory and CPU in the cluster - Need to confirm (getting inconsistent results). When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
 
 ## Internal / external naming
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are configured in the profile environmental vars files (no defaults set):
 | machine_amount_of_memory_mib   | ? | The amount of memory in MiB to allocate to the ocr-api.                                  |
 | ocr_tesseract_thread_pool_size | N | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
 
-- The **"Destroy"** column signifies that the environment must first be destroyed before applying this change to the environment,
+- The **"Destroy"** column signifies that the environment should first be destroyed before applying this change to the environment (the main problem seems to be when we change to a more powerful environment),
 - If you create a cluster with **more than two tasks,** only two tasks will be running after creation,
 - **Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type might define the overall memory and CPU in the cluster - Need to confirm (getting inconsistent results). When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are configured in the profile environmental vars files (no defaults set):
 | machine_amount_of_memory_mib    | The amount of memory in MiB to allocate to the ocr-api.                                  |
 | ocr_tesseract_thread_pool_size  | The number of threads used in the ocr-api application for Tesseract processing (Image to text) |
 
-** Make sure that the CPU and Memory values are in the range of the ec2_instance_type (the plan will be made and applied but fail in deployment with no clear error messages).
+**Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type defines the overall memory and CPU in the cluster. When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
 
 ## Internal / external naming
 

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -15,18 +15,13 @@ ec2_key_pair_name = "chs-cidev"
 
 # app configs
 log_level = "DEBUG"
-ocr_tesseract_thread_pool_size = "2"
+ocr_tesseract_thread_pool_size = "4"
 
 # app cluster performance
-#ec2_instance_type = "t3.medium"
-number_of_tasks = 1
-
-ec2_instance_type = "c5.xlarge"
-
+ec2_instance_type = "t3.medium"
+number_of_tasks = 2
 
 # machine properties
-machine_cpu_count = 2
-machine_amount_of_memory_mib = 2048
 
-#machine_cpu_count = 4
-#machine_amount_of_memory_mib = 8000
+machine_cpu_count = 2
+machine_amount_of_memory_mib = 3068

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -18,9 +18,15 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "2"
 
 # app cluster performance
-ec2_instance_type = "t3.medium"
+#ec2_instance_type = "t3.medium"
 number_of_tasks = 1
+
+ec2_instance_type = "c5.xlarge"
+
 
 # machine properties
 machine_cpu_count = 2
-machine_amount_of_memory_mib = 3072
+machine_amount_of_memory_mib = 2048
+
+#machine_cpu_count = 4
+#machine_amount_of_memory_mib = 8000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -18,14 +18,15 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "4"
 
 # app cluster performance
-ec2_instance_type = "c5.xlarge"
-number_of_tasks = 2
+ec2_instance_type = "t3.xlarge"
+number_of_tasks = 8
 
 # machine properties
 machine_cpu_count = 4
-machine_amount_of_memory_mib = 7000
+machine_amount_of_memory_mib = 8000
 
 
 # Testing history
 # Test 1 - ocr_tesseract_thread_pool_size = "3" ec2_instance_type = "t3.medium" number_of_tasks = 1 machine_cpu_count = 2 machine_amount_of_memory_mib = 2048
-# Test 1 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
+# Test 2 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
+# Test 3 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "t3.xlarge" number_of_tasks = 8 machine_cpu_count = 4 machine_amount_of_memory_mib = 8000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -18,9 +18,15 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
-ec2_instance_type = "t3.medium"
+#ec2_instance_type = "t3.medium"
 number_of_tasks = 1
 
+ec2_instance_type = "c5.xlarge"
+
+
 # machine properties
-machine_cpu_count = 2
-machine_amount_of_memory_mib = 2048
+#machine_cpu_count = 2
+#machine_amount_of_memory_mib = 2048
+
+machine_cpu_count = 4
+machine_amount_of_memory_mib = 8000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -15,14 +15,14 @@ ec2_key_pair_name = "chs-parent1"
 
 # app configs
 log_level = "DEBUG"
-ocr_tesseract_thread_pool_size = "12"
+ocr_tesseract_thread_pool_size = "16"
 
 # app cluster performance
-ec2_instance_type = "z1d.3xlarge"
+ec2_instance_type = "c5n.4xlarge"
 number_of_tasks = 2
 
 # machine properties
-machine_cpu_count = 12
+machine_cpu_count = 16
 machine_amount_of_memory_mib = 7000
 
 
@@ -33,3 +33,4 @@ machine_amount_of_memory_mib = 7000
 # Test config 4 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 14000
 # Test config 5 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 7000
 # Test config 6 - ocr_tesseract_thread_pool_size = "12" ec2_instance_type = "z1d.3xlarge" number_of_tasks = 2 machine_cpu_count = 12 machine_amount_of_memory_mib = 7000
+# Test config 7 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c5n.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 7000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -22,7 +22,7 @@ ec2_instance_type = "z1d.3xlarge"
 number_of_tasks = 2
 
 # machine properties
-machine_cpu_count = 16
+machine_cpu_count = 12
 machine_amount_of_memory_mib = 7000
 
 

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -23,7 +23,7 @@ number_of_tasks = 2
 
 # machine properties
 machine_cpu_count = 16
-machine_amount_of_memory_mib = 14000
+machine_amount_of_memory_mib = 7000
 
 
 # Testing history
@@ -31,3 +31,4 @@ machine_amount_of_memory_mib = 14000
 # Test 2 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
 # Test 3 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 28000
 # Test 4 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 14000
+# Test 5 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 7000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -21,12 +21,12 @@ ocr_tesseract_thread_pool_size = "3"
 #ec2_instance_type = "t3.medium"
 number_of_tasks = 1
 
-ec2_instance_type = "c5.xlarge"
+#ec2_instance_type = "c5.xlarge"
 
 
 # machine properties
-#machine_cpu_count = 2
-#machine_amount_of_memory_mib = 2048
+machine_cpu_count = 2
+machine_amount_of_memory_mib = 2048
 
-machine_cpu_count = 4
-machine_amount_of_memory_mib = 8000
+#machine_cpu_count = 4
+#machine_amount_of_memory_mib = 8000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -23,4 +23,4 @@ number_of_tasks = 2
 
 # machine properties
 machine_cpu_count = 2
-machine_amount_of_memory_mib = 2048
+machine_amount_of_memory_mib = 3048

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -15,18 +15,18 @@ ec2_key_pair_name = "chs-parent1"
 
 # app configs
 log_level = "DEBUG"
-ocr_tesseract_thread_pool_size = "4"
+ocr_tesseract_thread_pool_size = "16"
 
 # app cluster performance
-ec2_instance_type = "t3.xlarge"
-number_of_tasks = 8
+ec2_instance_type = "c4.4xlarge"
+number_of_tasks = 2
 
 # machine properties
-machine_cpu_count = 4
-machine_amount_of_memory_mib = 8000
+machine_cpu_count = 16
+machine_amount_of_memory_mib = 28000
 
 
 # Testing history
 # Test 1 - ocr_tesseract_thread_pool_size = "3" ec2_instance_type = "t3.medium" number_of_tasks = 1 machine_cpu_count = 2 machine_amount_of_memory_mib = 2048
 # Test 2 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
-# Test 3 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "t3.xlarge" number_of_tasks = 8 machine_cpu_count = 4 machine_amount_of_memory_mib = 8000
+# Test 3 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 28000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -15,18 +15,17 @@ ec2_key_pair_name = "chs-parent1"
 
 # app configs
 log_level = "DEBUG"
-ocr_tesseract_thread_pool_size = "3"
+ocr_tesseract_thread_pool_size = "4"
 
 # app cluster performance
-ec2_instance_type = "t3.medium"
-number_of_tasks = 1
-
-#ec2_instance_type = "c5.xlarge"
-
+ec2_instance_type = "c5.xlarge"
+number_of_tasks = 2
 
 # machine properties
-machine_cpu_count = 2
-machine_amount_of_memory_mib = 2048
+machine_cpu_count = 4
+machine_amount_of_memory_mib = 7000
 
-#machine_cpu_count = 4
-#machine_amount_of_memory_mib = 8000
+
+# Testing history
+# Test 1 - ocr_tesseract_thread_pool_size = "3" ec2_instance_type = "t3.medium" number_of_tasks = 1 machine_cpu_count = 2 machine_amount_of_memory_mib = 2048
+# Test 1 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -19,7 +19,7 @@ ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
-number_of_tasks = 2
+number_of_tasks = 1
 
 # machine properties
 machine_cpu_count = 2

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -23,10 +23,11 @@ number_of_tasks = 2
 
 # machine properties
 machine_cpu_count = 16
-machine_amount_of_memory_mib = 28000
+machine_amount_of_memory_mib = 14000
 
 
 # Testing history
 # Test 1 - ocr_tesseract_thread_pool_size = "3" ec2_instance_type = "t3.medium" number_of_tasks = 1 machine_cpu_count = 2 machine_amount_of_memory_mib = 2048
 # Test 2 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
 # Test 3 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 28000
+# Test 4 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 14000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -15,18 +15,19 @@ ec2_key_pair_name = "chs-parent1"
 
 # app configs
 log_level = "DEBUG"
-ocr_tesseract_thread_pool_size = "16"
+ocr_tesseract_thread_pool_size = "12"
 
 # app cluster performance
-ec2_instance_type = "c4.4xlarge"
+ec2_instance_type = "z1d.3xlarge"
 number_of_tasks = 2
 
 # machine properties
-machine_cpu_count = 16
+machine_cpu_count = 12
 machine_amount_of_memory_mib = 28000
 
 
 # Testing history
-# Test 1 - ocr_tesseract_thread_pool_size = "3" ec2_instance_type = "t3.medium" number_of_tasks = 1 machine_cpu_count = 2 machine_amount_of_memory_mib = 2048
-# Test 2 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
-# Test 3 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 28000
+# Test config 1 - ocr_tesseract_thread_pool_size = "3" ec2_instance_type = "t3.medium" number_of_tasks = 1 machine_cpu_count = 2 machine_amount_of_memory_mib = 2048
+# Test config 2 - ocr_tesseract_thread_pool_size = "4" ec2_instance_type = "c5.xlarge" number_of_tasks = 2 machine_cpu_count = 4 machine_amount_of_memory_mib = 7000
+# Test config 3 - ocr_tesseract_thread_pool_size = "16" ec2_instance_type = "c4.4xlarge" number_of_tasks = 2 machine_cpu_count = 16 machine_amount_of_memory_mib = 28000
+# Test config 4 - ocr_tesseract_thread_pool_size = "12" ec2_instance_type = "z1d.3xlarge" number_of_tasks = 2 machine_cpu_count = 12 machine_amount_of_memory_mib = 28000

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -23,4 +23,4 @@ number_of_tasks = 2
 
 # machine properties
 machine_cpu_count = 2
-machine_amount_of_memory_mib = 3048
+machine_amount_of_memory_mib = 2048

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -18,7 +18,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "3"
 
 # app cluster performance
-#ec2_instance_type = "t3.medium"
+ec2_instance_type = "t3.medium"
 number_of_tasks = 1
 
 #ec2_instance_type = "c5.xlarge"

--- a/groups/stack/profiles/development-eu-west-2/spartan1/vars
+++ b/groups/stack/profiles/development-eu-west-2/spartan1/vars
@@ -1,0 +1,32 @@
+aws_bucket = "development-eu-west-2.terraform-state.ch.gov.uk"
+remote_state_bucket = "ch-development-terraform-state-london"
+environment = "spartan1"
+deploy_to = "development"
+state_prefix = "env:/development"
+aws_profile = "development-eu-west-2"
+
+# Certificate for https access through ALB
+ssl_certificate_id = "arn:aws:acm:eu-west-2:169942020521:certificate/189427a3-3662-41ca-85d8-e1f42b6ea07e"
+zone_id = "Z2KSI4Z5ZN9NT0"
+external_top_level_domain = ".spartan1.aws.chdev.org"
+internal_top_level_domain = "-spartan1.development.aws.internal"
+
+ec2_key_pair_name = "chs-spartan1"
+
+# app configs
+log_level = "DEBUG"
+ocr_tesseract_thread_pool_size = "2"
+
+# app cluster performance
+
+number_of_tasks = 1
+
+ec2_instance_type = "t3.medium"
+
+
+# machine properties
+machine_cpu_count = 2
+machine_amount_of_memory_mib = 2048
+
+#machine_cpu_count = 4
+#machine_amount_of_memory_mib = 8000

--- a/groups/stack/profiles/staging-eu-west-2/staging/vars
+++ b/groups/stack/profiles/staging-eu-west-2/staging/vars
@@ -1,14 +1,16 @@
 aws_bucket = "staging-eu-west-2.terraform-state.ch.gov.uk"
 remote_state_bucket = "ch-service-staging-terraform-state"
-environment = "stagsbox"
+environment = "staging"
 deploy_to = "staging"
 state_prefix = "env:/staging"
 aws_profile = "staging-eu-west-2"
 
 # Certificate for https access through ALB
 ssl_certificate_id = "arn:aws:iam::250991044064:server-certificate/Staging_2022"
-external_top_level_domain = "-stagsbox.companieshouse.gov.uk"
-internal_top_level_domain = "-stagsbox.staging.aws.internal"
+# The below fields are not currently used for staging since we do not use Route 53 in this environment
+# Need to raise a SN with the netword team to get LB to connect to ocr-api-staging.companieshouse.gov.uk
+external_top_level_domain = "-staging.companieshouse.gov.uk"
+internal_top_level_domain = "staging.aws.internal"
 
 ec2_key_pair_name = "ch-aws-staging"
 

--- a/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
+++ b/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
@@ -1,0 +1,25 @@
+aws_bucket = "staging-eu-west-2.terraform-state.ch.gov.uk"
+remote_state_bucket = "ch-service-staging-terraform-state"
+environment = "stagsbox"
+deploy_to = "staging"
+state_prefix = "env:/staging"
+aws_profile = "staging-eu-west-2"
+
+# Certificate for https access through ALB
+ssl_certificate_id = "arn:aws:iam::250991044064:server-certificate/Staging_2022"
+external_top_level_domain = "-stagsbox.companieshouse.gov.uk"
+internal_top_level_domain = "-stagsbox.staging.aws.internal"
+
+ec2_key_pair_name = "ch-aws-staging"
+
+# app configs
+log_level = "DEBUG"
+ocr_tesseract_thread_pool_size = "4"
+
+# app cluster performance
+ec2_instance_type = "t3.medium"
+number_of_tasks = 2
+
+# machine properties
+machine_cpu_count = 2
+machine_amount_of_memory_mib = 3048

--- a/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
+++ b/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
@@ -18,7 +18,7 @@ ocr_tesseract_thread_pool_size = "4"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"
-number_of_tasks = 2
+number_of_tasks = 1
 
 # machine properties
 machine_cpu_count = 2

--- a/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
+++ b/groups/stack/profiles/staging-eu-west-2/stagsbox/vars
@@ -22,4 +22,4 @@ number_of_tasks = 2
 
 # machine properties
 machine_cpu_count = 2
-machine_amount_of_memory_mib = 3048
+machine_amount_of_memory_mib = 2048


### PR DESCRIPTION
Jira: ivp 1351

Add Staging environment for ocr-api-stack

Also update readme and other environments while performance testing

Spartan environment just used to test out terraform features without effecting testing (it is otherwise unused). This is just run in via Terraform scripts while the other environments are run in via Concourse