### PR TITLE
Add cloudwatch dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Infrastructure for the OCR Service stack.
 
-This consists of one or more ECS Clusters. Each Cluster has a ELB with one microservice (`ocr-api`)
+This consists of one or more ECS Clusters. Each Cluster has a ELB with one microservice (`ocr-api`) and a CloudWatch dashboard
 
 ## Performance Variables
 
@@ -37,8 +37,12 @@ No secrets are required in this application stack
 
 The `ocr-api` dashboard is created originally manually using the parent1 environment and then it is exported to the file `groups/stack/module-cloudwatch/dashboard.tmpl` and the following transformations made:
 
--  `app/ocr-api-parent1-lb/15c21529930662af` -> `${elb_arn_suffix}` (example `"app/ocr-api-parent1-lb/15c21529930662af"`-> "${elb_arn_suffix}")
-- `parent` -> `${environment}/`  (example ` "query": "SOURCE '/ecs/ocr-api-parent1/ocr-api'` -> ` "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api'`)
+- `app/ocr-api-parent1-lb/15c21529930662af` -> `${elb_arn_suffix}` (example `"app/ocr-api-parent1-lb/15c21529930662af"`-> "${elb_arn_suffix}")
+- `parent1` -> `${environment}`  (example `"query": "SOURCE '/ecs/ocr-api-parent1/ocr-api'` -> `"query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api'`)
 - `platform**` -> `${environment}**`
 
-The dashboard is made from CloudWatch logs and metrics (both general one such as the ELB Errors, CPU Utilization and project specific metrics such as queue-size-above-zero)
+The "Golden ruLe" when doing the above is that every widget with data in the Dashboard should have at lease one transformation performed.
+
+The dashboard is made from CloudWatch logs and "metric filter" and metrics (such as the ELB Errors, CPU Utilization).
+
+The logs and metric filter based dashboard widgets are dependent on events emitted from the [ocr-api](https://github.com/companieshouse/ocr-api) microservice.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ These are configured in the profile environmental vars files (no defaults set):
 | `ocr_tesseract_thread_pool_size` | N | The number of threads used in the `ocr-api` application for Tesseract processing (Image to text) |
 | `ocr_queue_capacity`             | N | The capacity of the queue used in the `ocr-api` application for Tesseract processing (Image to text) |
 
-
 - The **"Destroy"** column signifies that the environment should first be destroyed before applying this change to the environment (the main problem seems to be when we change to a more powerful environment),
 - If you create a cluster with **more than two tasks,** only two tasks will be running after creation,
 - **Make sure that the CPU and Memory values are in the range of the ec2_instance_type.**  The instance type might define the overall memory and CPU in the cluster - Need to confirm (getting inconsistent results). When these do NOT match, the plan will be made and applied but fail in deployment with no clear error messages.
@@ -33,3 +32,13 @@ Notes on the internal / external naming:
 ## Secrets
 
 No secrets are required in this application stack
+
+## Dashboard
+
+The `ocr-api` dashboard is created originally manually using the parent1 environment and then it is exported to the file `groups/stack/module-cloudwatch/dashboard.tmpl` and the following transformations made:
+
+-  `app/ocr-api-parent1-lb/15c21529930662af` -> `${elb_arn_suffix}` (example `"app/ocr-api-parent1-lb/15c21529930662af"`-> "${elb_arn_suffix}")
+- `parent` -> `${environment}/`  (example ` "query": "SOURCE '/ecs/ocr-api-parent1/ocr-api'` -> ` "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api'`)
+- `platform**` -> `${environment}**`
+
+The dashboard is made from CloudWatch logs and metrics (both general one such as the ELB Errors, CPU Utilization and project specific metrics such as queue-size-above-zero)

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -131,7 +131,6 @@ module "ecs-services" {
   docker_registry           = var.docker_registry
   log_level                 = var.log_level
 
-  
   # ocr-api variables
   ocr_api_application_port       = "8080"
   ocr_api_release_version        = var.ocr_api_release_version
@@ -142,4 +141,12 @@ module "ecs-services" {
   # machine properties
   machine_cpu_count              = var.machine_cpu_count
   machine_amount_of_memory_mib   = var.machine_amount_of_memory_mib
+}
+
+# CloudWatch Dashboard
+module "cloudwatch" {
+  source = "./module-cloudwatch"
+  aws_region              = var.aws_region
+  elb_arn_suffix          = module.ecs-stack.elb_arn_suffix
+  environment             = var.environment
 }

--- a/groups/stack/module-cloudwatch/dashboard.tf
+++ b/groups/stack/module-cloudwatch/dashboard.tf
@@ -3,8 +3,6 @@ resource "aws_cloudwatch_log_metric_filter" "requests-on-queue_metric_filter" {
   pattern        = "{ ($.data.log_record_name = \"ocr_statistics\") && ($.data.queue_size > 0) }"
   log_group_name = "/ecs/ocr-api-${var.environment}/ocr-api"
 
- # Support for unit attribute in Add support for unit 3.47.0 (June 24, 2021) https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md
- # ideally set: unit = "Count"
   metric_transformation {
     name          = "queue-size-above-zero"
     namespace     = "ocr-api-metrics-${var.environment}"

--- a/groups/stack/module-cloudwatch/dashboard.tf
+++ b/groups/stack/module-cloudwatch/dashboard.tf
@@ -1,3 +1,19 @@
+resource "aws_cloudwatch_log_metric_filter" "requests-on-queue_metric_filter" {
+  name           = "requests-on-queue-${var.environment}"
+  pattern        = "{ ($.data.log_record_name = \"ocr_statistics\") && ($.data.queue_size > 0) }"
+  log_group_name = "/ecs/ocr-api-${var.environment}/ocr-api"
+
+ # Support for unit attribute in Add support for unit 3.47.0 (June 24, 2021) https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md
+ # ideally set: unit = "Count"
+  metric_transformation {
+    name          = "queue-size-above-zero"
+    namespace     = "ocr-api-metrics-${var.environment}"
+    value         = "$.data.queue_size"
+    default_value = 0
+  }
+}
+
+
 resource "aws_cloudwatch_dashboard" "ocr_api_dashboard" {
   dashboard_name = "ocr-api-${var.environment}"
 
@@ -8,3 +24,4 @@ resource "aws_cloudwatch_dashboard" "ocr_api_dashboard" {
   })
 
 }
+

--- a/groups/stack/module-cloudwatch/dashboard.tf
+++ b/groups/stack/module-cloudwatch/dashboard.tf
@@ -1,0 +1,10 @@
+resource "aws_cloudwatch_dashboard" "ocr_api_dashboard" {
+  dashboard_name = "ocr-api-${var.environment}"
+
+  dashboard_body = templatefile("${path.module}/dashboard.tmpl", {
+      environment             : var.environment
+      aws_region              : var.aws_region
+      elb_arn_suffix          : var.elb_arn_suffix
+  })
+
+}

--- a/groups/stack/module-cloudwatch/dashboard.tmpl
+++ b/groups/stack/module-cloudwatch/dashboard.tmpl
@@ -1,0 +1,322 @@
+{
+    "widgets": [
+        {
+            "height": 6,
+            "width": 6,
+            "y": 1,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_statistics' | stats avg(data.queue_size) by bin(30s)",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Queue Size (Ave/30s)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 13,
+            "x": 12,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields @message | filter @message like /error/ | stats count() by bin(15m)",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Application Errors (per 15 minutes)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 7,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'http_request' | stats count() by bin(60s)",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Image to Text Requests (per minute)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 1,
+            "x": 12,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_monitoring' | stats avg(data.time_on_queue_ms/60000) by bin(30s)",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Time in Queue (minutes)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 1,
+            "x": 18,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_monitoring' | stats avg(data.file_size) by bin(30s)",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Image Size (Ave Bytes/30s)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 19,
+            "x": 6,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApplicationELB", "HTTPCode_ELB_4XX_Count", "LoadBalancer", "${elb_arn_suffix}" ],
+                    [ ".", "HTTPCode_Target_5XX_Count", ".", ".", { "yAxis": "right" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "eu-west-2",
+                "title": "ELB Errors (per 15 minutes)",
+                "period": 900,
+                "stat": "Sum",
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    },
+                    "right": {
+                        "min": 0
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 13,
+            "x": 18,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApplicationELB", "NewConnectionCount", "LoadBalancer", "${elb_arn_suffix}", { "yAxis": "right" } ],
+                    [ ".", "TargetResponseTime", ".", "." ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "eu-west-2",
+                "title": "ELB Connectivity",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    },
+                    "right": {
+                        "min": 0
+                    }
+                },
+                "stat": "Average"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 1,
+            "x": 6,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "ocr-api-metrics", "queue-size-above-zero" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "eu-west-2",
+                "title": "Queue Size Metric (Max/30s)",
+                "period": 30,
+                "stat": "Maximum"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 13,
+            "x": 6,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields @message | filter @message like /error/ | stats count() by bin(60s)",
+                "region": "eu-west-2",
+                "title": "Application Errors (per minute)",
+                "view": "timeSeries",
+                "stacked": false
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 19,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApplicationELB", "HTTPCode_ELB_4XX_Count", "LoadBalancer", "${elb_arn_suffix}" ],
+                    [ ".", "HTTPCode_Target_5XX_Count", ".", ".", { "yAxis": "right" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "eu-west-2",
+                "title": "ELB Errors (per minute)",
+                "period": 60,
+                "stat": "Sum",
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    },
+                    "right": {
+                        "min": 0
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 7,
+            "x": 6,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_monitoring' | stats avg(data.total_processing_time_ms/60000) by bin(30s)\n",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Total Txn Time (minutes)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 7,
+            "x": 12,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_monitoring' and   data.result_code = '0' | stats avg(data.ocr_processing_time_ms/60000) by bin(30s)",
+                "region": "eu-west-2",
+                "stacked": false,
+                "title": "Image to Text Time (minutes)",
+                "view": "timeSeries"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 7,
+            "x": 18,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_monitoring' and   data.result_code = '0' | stats count() by bin(60s)",
+                "region": "eu-west-2",
+                "title": "Successful Txn (per minute)",
+                "view": "timeSeries",
+                "stacked": false
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 13,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/ecs/ocr-api-${environment}/ocr-api' | fields data | filter data.log_record_name = 'ocr_monitoring' and data.result_code = '503' | stats count() by bin(60s)\n",
+                "region": "eu-west-2",
+                "title": "App Overload Errors (per minute)",
+                "view": "timeSeries",
+                "stacked": false
+            }
+        },
+        {
+            "height": 1,
+            "width": 24,
+            "y": 0,
+            "x": 0,
+            "type": "text",
+            "properties": {
+                "markdown": "# **OCR Service Dashboard - ${environment}**"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 19,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "id": "expr1m0", "label": "ocr-api-${environment}-cluster", "expression": "mm1m0 * 100 / mm0m0", "stat": "Average", "region": "eu-west-2" } ],
+                    [ "ECS/ContainerInsights", "CpuReserved", "ClusterName", "ocr-api-${environment}-cluster", { "id": "mm0m0", "visible": false } ],
+                    [ ".", "CpuUtilized", ".", ".", { "id": "mm1m0", "visible": false } ]
+                ],
+                "region": "eu-west-2",
+                "title": "CPU Utilization",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "liveData": false,
+                "period": 60,
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "showUnits": false,
+                        "label": "Percent"
+                    },
+                    "right": {
+                        "min": 0
+                    }
+                },
+                "view": "timeSeries",
+                "stacked": false,
+                "stat": "Sum"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 19,
+            "x": 18,
+            "type": "metric",
+            "properties": {
+                "region": "eu-west-2",
+                "title": "Memory Utilization",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ { "id": "expr1m0", "label": "ocr-api-${environment}-cluster", "expression": "mm1m0 * 100 / mm0m0", "stat": "Average", "region": "eu-west-2" } ],
+                    [ "ECS/ContainerInsights", "MemoryReserved", "ClusterName", "ocr-api-${environment}-cluster", { "id": "mm0m0", "visible": false, "stat": "Sum" } ],
+                    [ ".", "MemoryUtilized", ".", ".", { "id": "mm1m0", "visible": false, "stat": "Sum" } ]
+                ],
+                "liveData": false,
+                "period": 60,
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "showUnits": false,
+                        "label": "Percent"
+                    },
+                    "right": {
+                        "min": 0
+                    }
+                },
+                "view": "timeSeries",
+                "stacked": false
+            }
+        }
+    ]
+}

--- a/groups/stack/module-cloudwatch/dashboard.tmpl
+++ b/groups/stack/module-cloudwatch/dashboard.tmpl
@@ -132,7 +132,7 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "ocr-api-metrics", "queue-size-above-zero" ]
+                    [ "ocr-api-metrics-${environment}", "queue-size-above-zero" ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,

--- a/groups/stack/module-cloudwatch/variables.tf
+++ b/groups/stack/module-cloudwatch/variables.tf
@@ -1,0 +1,26 @@
+//----------------------------------------------------------------------
+// Standard Variables
+//----------------------------------------------------------------------
+variable "environment" {
+  description = "The name of the environment this cluster is part of e.g. live, staging, dev. etc."
+  type        = string
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables
+# ------------------------------------------------------------------------------
+variable "aws_region" {
+  type        = string
+  description = "The AWS region in which resources will be administered"
+}
+
+#
+//----------------------------------------------------------------------
+// Load Balancer Variables
+//----------------------------------------------------------------------
+variable "elb_arn_suffix" {
+  type = string
+  description = "The Load Balancer ARN suffix for use with CloudWatch Metrics."
+}
+
+

--- a/groups/stack/module-cloudwatch/variables.tf
+++ b/groups/stack/module-cloudwatch/variables.tf
@@ -1,6 +1,6 @@
-//----------------------------------------------------------------------
-// Standard Variables
-//----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+#  Standard Variables
+# ----------------------------------------------------------------------
 variable "environment" {
   description = "The name of the environment this cluster is part of e.g. live, staging, dev. etc."
   type        = string
@@ -15,9 +15,9 @@ variable "aws_region" {
 }
 
 #
-//----------------------------------------------------------------------
-// Load Balancer Variables
-//----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+#  Load Balancer Variables
+# ----------------------------------------------------------------------
 variable "elb_arn_suffix" {
   type = string
   description = "The Load Balancer ARN suffix for use with CloudWatch Metrics."

--- a/groups/stack/module-ecs-stack/output.tf
+++ b/groups/stack/module-ecs-stack/output.tf
@@ -5,3 +5,7 @@ output "ocr-api-lb-listener-arn" {
 output "ocr-api-lb-arn" {
   value = aws_lb.ocr-api-lb.arn
 }
+
+output "elb_arn_suffix" {
+  value = aws_lb.ocr-api-lb.arn_suffix
+}


### PR DESCRIPTION
Jira: IVP-1492 (two sub tasks)

A new metric filter and a CloudWatch dashboard will now be available for each environment the OCR service is deployed to. This makes it easier to monitor this service