### PR TITLE
Allow heritage subnets to access the api

### DIFF
--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -73,27 +73,36 @@ provider "vault" {
   }
 }
 
+data "vault_generic_secret" "heritage_application_cidrs" {
+  path = "/aws-accounts/network/${var.aws_account_name}/heritage/application-subnets"
+}
+
 locals {
   # stack name is hardcoded here in main.tf for this stack. It should not be overridden per env
-  stack_name       = "ocr-api"
-  stack_fullname   = "${local.stack_name}-stack"
-  name_prefix      = "${local.stack_name}-${var.environment}"
+  stack_name     = "ocr-api"
+  stack_fullname = "${local.stack_name}-stack"
+  name_prefix    = "${local.stack_name}-${var.environment}"
+
+  heritage_application_cidrs = values(data.vault_generic_secret.heritage_application_cidrs.data)
+  web_access_cidrs = concat(local.internal_cidrs, local.vpn_cidrs, local.management_private_subnet_cidrs,
+  split(",", local.application_cidrs), local.heritage_application_cidrs)
+
 }
 
 module "ecs-cluster" {
-  source = "git::git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.2"
+  source = "git::git@github.com:companieshouse/terraform-library-ecs-cluster.git?ref=1.1.3"
 
-  stack_name                 = local.stack_name
-  name_prefix                = local.name_prefix
-  environment                = var.environment
-  vpc_id                     = local.vpc_id
-  subnet_ids                 = local.application_ids
-  ec2_key_pair_name          = var.ec2_key_pair_name
-  ec2_instance_type          = var.ec2_instance_type
-  ec2_image_id               = var.ec2_image_id
-  asg_max_instance_count     = var.asg_max_instance_count
-  asg_min_instance_count     = var.asg_min_instance_count
-  asg_desired_instance_count = var.asg_desired_instance_count
+  stack_name                    = local.stack_name
+  name_prefix                   = local.name_prefix
+  environment                   = var.environment
+  vpc_id                        = local.vpc_id
+  subnet_ids                    = local.application_ids
+  ec2_key_pair_name             = var.ec2_key_pair_name
+  ec2_instance_type             = var.ec2_instance_type
+  ec2_image_id                  = var.ec2_image_id
+  asg_max_instance_count        = var.asg_max_instance_count
+  asg_min_instance_count        = var.asg_min_instance_count
+  asg_desired_instance_count    = var.asg_desired_instance_count
   container_insights_enablement = var.container_insights_enablement
 }
 
@@ -109,7 +118,7 @@ module "ecs-stack" {
   external_top_level_domain = var.external_top_level_domain
   internal_top_level_domain = var.internal_top_level_domain
   subnet_ids                = local.application_ids
-  web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
+  web_access_cidrs          = local.web_access_cidrs
 }
 
 module "ecs-services" {
@@ -117,11 +126,10 @@ module "ecs-services" {
 
   name_prefix               = local.name_prefix
   environment               = var.environment
-  tocr-api-lb-arn          = module.ecs-stack.ocr-api-lb-listener-arn
-  ocr-api-lb-listener-arn = module.ecs-stack.ocr-api-lb-listener-arn
+  tocr-api-lb-arn           = module.ecs-stack.ocr-api-lb-listener-arn
+  ocr-api-lb-listener-arn   = module.ecs-stack.ocr-api-lb-listener-arn
   vpc_id                    = local.vpc_id
   subnet_ids                = local.application_ids
-  web_access_cidrs          = concat(local.internal_cidrs,local.vpn_cidrs,local.management_private_subnet_cidrs,split(",",local.application_cidrs))
   aws_region                = var.aws_region
   ssl_certificate_id        = var.ssl_certificate_id
   external_top_level_domain = var.external_top_level_domain
@@ -140,14 +148,14 @@ module "ecs-services" {
   number_of_tasks                = var.number_of_tasks
 
   # machine properties
-  machine_cpu_count              = var.machine_cpu_count
-  machine_amount_of_memory_mib   = var.machine_amount_of_memory_mib
+  machine_cpu_count            = var.machine_cpu_count
+  machine_amount_of_memory_mib = var.machine_amount_of_memory_mib
 }
 
 # CloudWatch Dashboard
 module "cloudwatch" {
-  source = "./module-cloudwatch"
-  aws_region              = var.aws_region
-  elb_arn_suffix          = module.ecs-stack.elb_arn_suffix
-  environment             = var.environment
+  source         = "./module-cloudwatch"
+  aws_region     = var.aws_region
+  elb_arn_suffix = module.ecs-stack.elb_arn_suffix
+  environment    = var.environment
 }

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -25,10 +25,6 @@ variable "subnet_ids" {
   type        = string
   description = "Subnet IDs of application subnets from aws-mm-networks remote state."
 }
-variable "web_access_cidrs" {
-  type        = list(string)
-  description = "Subnet CIDRs for web ingress rules in the security group."
-}
 
 # DNS
 variable "external_top_level_domain" {

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -4,6 +4,7 @@ environment = "cidev"
 deploy_to = "development"
 state_prefix = "env:/development"
 aws_profile = "development-eu-west-2"
+aws_account_name = "ch-development"
 
 # Certificate for https access through ALB
 ssl_certificate_id = "arn:aws:acm:eu-west-2:169942020521:certificate/8d7db053-7416-4e56-946b-762d0a34c899"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -4,6 +4,7 @@ environment = "parent1"
 deploy_to = "development"
 state_prefix = "env:/development"
 aws_profile = "development-eu-west-2"
+aws_account_name = "ch-development"
 
 # Certificate for https access through ALB
 ssl_certificate_id = "arn:aws:acm:eu-west-2:169942020521:certificate/9185ee37-c2d0-4de1-a9fc-00ab77b79317"

--- a/groups/stack/profiles/development-eu-west-2/spartan1/vars
+++ b/groups/stack/profiles/development-eu-west-2/spartan1/vars
@@ -4,6 +4,7 @@ environment = "spartan1"
 deploy_to = "development"
 state_prefix = "env:/development"
 aws_profile = "development-eu-west-2"
+aws_account_name = "ch-development"
 
 # Certificate for https access through ALB
 ssl_certificate_id = "arn:aws:acm:eu-west-2:169942020521:certificate/189427a3-3662-41ca-85d8-e1f42b6ea07e"

--- a/groups/stack/profiles/live-eu-west-2/live/vars
+++ b/groups/stack/profiles/live-eu-west-2/live/vars
@@ -4,6 +4,7 @@ environment = "live"
 deploy_to = "live"
 state_prefix = "env:/live"
 aws_profile = "live-eu-west-2"
+aws_account_name = "ch-live"
 
 
 # Certificate for https access through ALB 

--- a/groups/stack/profiles/live-eu-west-2/live/vars
+++ b/groups/stack/profiles/live-eu-west-2/live/vars
@@ -7,7 +7,7 @@ aws_profile = "live-eu-west-2"
 
 
 # Certificate for https access through ALB 
-ssl_certificate_id = "arn:aws:iam::449229032822:server-certificate/starCertExpOct2021"
+ssl_certificate_id = "arn:aws:acm:eu-west-2:449229032822:certificate/5c57a264-3168-4de8-8767-40fd0cedebf0"
 
 # The below fields are not currently used for live since we do not use Route 53 in this environment
 # Need to raise a SN with the network team to get LB to connect to ocr-api.companieshouse.gov.uk

--- a/groups/stack/profiles/staging-eu-west-2/staging/vars
+++ b/groups/stack/profiles/staging-eu-west-2/staging/vars
@@ -4,6 +4,7 @@ environment = "staging"
 deploy_to = "staging"
 state_prefix = "env:/staging"
 aws_profile = "staging-eu-west-2"
+aws_account_name = "ch-staging"
 
 # Certificate for https access through ALB
 ssl_certificate_id = "arn:aws:acm:eu-west-2:250991044064:certificate/56b76dab-5728-4f83-a16d-e3dd59cd82c8"

--- a/groups/stack/profiles/staging-eu-west-2/staging/vars
+++ b/groups/stack/profiles/staging-eu-west-2/staging/vars
@@ -6,7 +6,7 @@ state_prefix = "env:/staging"
 aws_profile = "staging-eu-west-2"
 
 # Certificate for https access through ALB
-ssl_certificate_id = "arn:aws:iam::250991044064:server-certificate/starCertExpOct2021"
+ssl_certificate_id = "arn:aws:acm:eu-west-2:250991044064:certificate/56b76dab-5728-4f83-a16d-e3dd59cd82c8"
 
 # The below fields are not currently used for staging since we do not use Route 53 in this environment
 # Need to raise a SN with the netword team to get LB to connect to ocr-api-staging.companieshouse.gov.uk

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -13,6 +13,10 @@ variable "aws_profile" {
   type        = string
   description = "The AWS profile to use for deployment."
 }
+variable "aws_account_name" {
+  type        = string
+  description = "The aws account name name, defined in envrionments vars."
+}
 
 # Terraform
 variable "aws_bucket" {
@@ -72,7 +76,7 @@ variable "ec2_image_id" {
 }
 variable "number_of_tasks" {
   type        = number
-  description = "The number of instances of the ocr-api task to run" 
+  description = "The number of instances of the ocr-api task to run"
 }
 variable "container_insights_enablement" {
   description = "Whether container insights are set, valid values are [enabled,disabled]"
@@ -105,7 +109,7 @@ variable "ssl_certificate_id" {
 
 # DNS
 variable "zone_id" {
-  default = "" # default of empty string is used as conditional when creating route53 records i.e. if no zone_id provided then no route53
+  default     = "" # default of empty string is used as conditional when creating route53 records i.e. if no zone_id provided then no route53
   type        = string
   description = "The ID of the hosted zone to contain the Route 53 record."
 }

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -15,7 +15,7 @@ variable "aws_profile" {
 }
 variable "aws_account_name" {
   type        = string
-  description = "The aws account name name, defined in envrionments vars."
+  description = "The aws account name, defined in envrionments vars."
 }
 
 # Terraform


### PR DESCRIPTION
Adds the heritage application subnet cidrs to the ALB ingress rules to allow http/https access from cloud CHIPS etc.

Also updates the referenced SSL certs for staging and live, and updates the version of the terraform-library-ecs-cluster module to remove deprecation warnings.

Resolves: https://companieshouse.atlassian.net/browse/CM-1010