### PR TITLE
Add new env vars across environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These are configured in the profile environmental vars files (no defaults set):
 | `ocr_tesseract_thread_pool_size` | N | The number of threads used in the `ocr-api` application for Tesseract processing (Image to text) |
 | `ocr_queue_capacity`             | N | The capacity of the queue used in the `ocr-api` application for Tesseract processing (Image to text) |
 | `low_confidence_to_log`          | N | The minimum confidence value used for logging low confidence scores (logs any confidence scores lower than the value set) |
+| `host_white_list`                | N | The list of acceptable callback URL hosts that the `ocr-api` applicaton can accept in a request |
 
 
 - The **"Destroy"** column signifies that the environment should first be destroyed before applying this change to the environment (the main problem seems to be when we change to a more powerful environment),

--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -146,6 +146,7 @@ module "ecs-services" {
   ocr_queue_capacity             = var.ocr_queue_capacity
   low_confidence_to_log          = var.low_confidence_to_log
   number_of_tasks                = var.number_of_tasks
+  host_white_list                = var.host_white_list
 
   # machine properties
   machine_cpu_count            = var.machine_cpu_count

--- a/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/ocr-api-task-definition.tmpl
@@ -4,7 +4,8 @@
             { "name": "LOGLEVEL", "value": "${log_level}" },
             { "name" : "OCR_TESSERACT_THREAD_POOL_SIZE", "value": "${ocr_tesseract_thread_pool_size}" },
             { "name" : "OCR_QUEUE_CAPACITY", "value": "${ocr_queue_capacity}" },
-            { "name" : "LOW_CONFIDENCE_TO_LOG", "value": "${low_confidence_to_log}" }
+            { "name" : "LOW_CONFIDENCE_TO_LOG", "value": "${low_confidence_to_log}" },
+            { "name" : "HOST_WHITE_LIST", "value": "${host_white_list}" }
         ],
         "name": "${service_name}",
         "image": "${docker_registry}/${service_name}:${ocr_api_release_version}",

--- a/groups/stack/module-ecs-services/ocr-api.tf
+++ b/groups/stack/module-ecs-services/ocr-api.tf
@@ -32,6 +32,7 @@ locals {
       ocr_queue_capacity             : var.ocr_queue_capacity
       low_confidence_to_log          : var.low_confidence_to_log
       number_of_tasks                : var.number_of_tasks
+      host_white_list                : var.host_white_list
 
       # machine properties
       machine_cpu_count              : var.machine_cpu_count

--- a/groups/stack/module-ecs-services/variables.tf
+++ b/groups/stack/module-ecs-services/variables.tf
@@ -75,6 +75,10 @@ variable "low_confidence_to_log" {
   type        = string
   description = "The minimum confidence value used for logging low confidence scores (logs any confidence scores lower than the value set)"
 }
+variable "host_white_list" {
+  type        = string
+  description = "The list of acceptable callback URL hosts that the `ocr-api` applicaton can accept in a request)"
+}
 
 # Certificates
 variable "ssl_certificate_id" {

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -19,7 +19,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "4"
 ocr_queue_capacity = "4"
 low_confidence_to_log = "40"
-host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch"
+host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch,chpdev-sl6,chpdev-sl6.internal.ch,chpdev-pl7,chpdev-pl7.internal.ch,chpdev-pl6,chpdev-pl6.internal.ch"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"

--- a/groups/stack/profiles/development-eu-west-2/cidev/vars
+++ b/groups/stack/profiles/development-eu-west-2/cidev/vars
@@ -19,6 +19,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "4"
 ocr_queue_capacity = "4"
 low_confidence_to_log = "40"
+host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -20,7 +20,7 @@ log_level = "DEBUG"
 low_confidence_to_log = "40"
 ocr_tesseract_thread_pool_size = "4"
 ocr_queue_capacity = "4"
-host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch"
+host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch,chpdev-sl6,chpdev-sl6.internal.ch,chpdev-pl7,chpdev-pl7.internal.ch,chpdev-pl6,chpdev-pl6.internal.ch"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"

--- a/groups/stack/profiles/development-eu-west-2/parent1/vars
+++ b/groups/stack/profiles/development-eu-west-2/parent1/vars
@@ -20,6 +20,7 @@ log_level = "DEBUG"
 low_confidence_to_log = "40"
 ocr_tesseract_thread_pool_size = "4"
 ocr_queue_capacity = "4"
+host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"

--- a/groups/stack/profiles/development-eu-west-2/spartan1/vars
+++ b/groups/stack/profiles/development-eu-west-2/spartan1/vars
@@ -19,7 +19,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "2"
 ocr_queue_capacity = "4"
 low_confidence_to_log = "0"
-host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch"
+host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch,chpdev-sl6,chpdev-sl6.internal.ch,chpdev-pl7,chpdev-pl7.internal.ch,chpdev-pl6,chpdev-pl6.internal.ch"
 
 # app cluster performance
 

--- a/groups/stack/profiles/development-eu-west-2/spartan1/vars
+++ b/groups/stack/profiles/development-eu-west-2/spartan1/vars
@@ -19,6 +19,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "2"
 ocr_queue_capacity = "4"
 low_confidence_to_log = "0"
+host_white_list = "chpdev-sl7,chpdev-sl7.internal.ch"
 
 # app cluster performance
 

--- a/groups/stack/profiles/live-eu-west-2/live/vars
+++ b/groups/stack/profiles/live-eu-west-2/live/vars
@@ -22,6 +22,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "12"
 ocr_queue_capacity = "20"
 low_confidence_to_log = "0"
+host_white_list = "chips.companieshouse.gov.uk"
 
 # app cluster performance
 ec2_instance_type = "z1d.3xlarge"

--- a/groups/stack/profiles/staging-eu-west-2/staging/vars
+++ b/groups/stack/profiles/staging-eu-west-2/staging/vars
@@ -21,6 +21,7 @@ log_level = "DEBUG"
 ocr_tesseract_thread_pool_size = "4"
 ocr_queue_capacity = "5"
 low_confidence_to_log = "0"
+host_white_list = "chips-staging.companieshouse.gov.uk"
 
 # app cluster performance
 ec2_instance_type = "t3.medium"

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -59,6 +59,10 @@ variable "low_confidence_to_log" {
   type        = string
   description = "The minimum confidence value used for logging low confidence scores (logs any confidence scores lower than the value set)"
 }
+variable "host_white_list" {
+  type        = string
+  description = "The list of acceptable callback URL hosts that the `ocr-api` applicaton can accept in a request)"
+}
 
 # EC2
 variable "ec2_key_pair_name" {


### PR DESCRIPTION
Add host_white_list env var ocr-api across environments.
This is a new variable that is needed to accomodate new changes to the ocr-api application for URL validation 

[DEBT-1758](https://companieshouse.atlassian.net/browse/DEBT-1758)